### PR TITLE
Return false instead of error on empty input

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,5 @@
 var filenameReservedRegex = require('filename-reserved-regex');
 
 module.exports = function (str) {
-	return str.length <= 255 && !filenameReservedRegex().test(str);
+	return str && (str.length <= 255 && !filenameReservedRegex().test(str));
 };


### PR DESCRIPTION
Prevents function from throwing an error when `str` is null/undefined
