### PR TITLE
add Windows reserved names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - 'iojs'
-  - '0.12'
-  - '0.10'
+  - '6'
+  - '4'

--- a/index.js
+++ b/index.js
@@ -1,6 +1,14 @@
 'use strict';
-var filenameReservedRegex = require('filename-reserved-regex');
+var reserved = require('filename-reserved-regex');
 
-module.exports = function (str) {
-	return str && (str.length <= 255 && !filenameReservedRegex().test(str));
+module.exports = (str) => {
+	if (!str || str.length > 255) {
+		return false;
+	}
+
+	if (reserved().test(str) || reserved.windowsNames().test(str)) {
+		return false;
+	}
+
+	return true;
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "scripts": {
     "test": "ava"
@@ -32,7 +32,7 @@
     "string"
   ],
   "dependencies": {
-    "filename-reserved-regex": "^1.0.0"
+    "filename-reserved-regex": "^2.0.0"
   },
   "devDependencies": {
     "ava": "*"

--- a/test.js
+++ b/test.js
@@ -4,5 +4,14 @@ import fn from './';
 test(t => {
 	t.true(fn('foo-bar'));
 	t.false(fn('foo/bar'));
+	t.false(fn(''));
 	t.false(fn('<foo|bar>'));
+	t.false(fn('con'));
+	t.false(fn('aux'));
+	t.false(fn('com1'));
+	t.false(fn('lpt1'));
+	t.true(fn('nul1'));
+	t.true(fn('aux1'));
+	t.true(fn('a'.repeat(255)));
+	t.false(fn('a'.repeat(256)));
 });


### PR DESCRIPTION
Added the reserved names and removed the length check that does not strictly apply on Windows 10 any more as discussed in #2.

Should we keep the reserved names here or move them `filename-reserved-regex`? I opted not to because the modules just deals with invalid characters, not filenames.
